### PR TITLE
Autoload config provider in mezzio projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
                 "laminas/laminas-httphandlerrunner",
                 "mezzio/mezzio-fastroute",
                 "mezzio/mezzio-twigrenderer"
-            ]
+            ],
+            "component": "Settermjd\\MarkdownBlog",
+            "config-provider": "Settermjd\\MarkdownBlog\\ConfigProvider"
         }
     },
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0536b78d710395a93adf06bdee8d972d",
+    "content-hash": "131bb66b5bd0eb705bc2feeb9be87fe5",
     "packages": [
         {
             "name": "brick/varexporter",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

To help ensure that the project is as simple to use as possible, this change instructs Mezzio projects to autoload the package's `ConfigProvider` class when the package is installed.
