### PR TITLE
Add handlers for the blog index and article view page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         }
     },
     "require": {
-        "php": "~8.1.0||~8.2.0||~8.3.0||~8.4.0",
+        "php": "~8.3.0||~8.4.0",
         "composer/package-versions-deprecated": "^1.11.99.5",
         "laminas/laminas-component-installer": "^3.5.0",
         "laminas/laminas-config-aggregator": "^1.18.0",

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace Settermjd\MarkdownBlog;
 
 use Laminas\InputFilter\InputFilterInterface;
+use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
+use Mezzio\Application;
+use Mezzio\Container\ApplicationConfigInjectionDelegator;
+use Settermjd\MarkdownBlog\Handler\BlogArticleHandler;
+use Settermjd\MarkdownBlog\Handler\BlogIndexHandler;
 use Settermjd\MarkdownBlog\InputFilter\BlogArticleInputFilterFactory;
 use Settermjd\MarkdownBlog\Items\ItemListerFactory;
 use Settermjd\MarkdownBlog\Items\ItemListerInterface;
 
 /**
- * The configuration provider for the MarkdownBlog module
+ * The configuration provider for the module
  *
  * @see https://docs.laminas.dev/laminas-component-installer/
  */
@@ -28,20 +33,69 @@ final class ConfigProvider
     {
         return [
             'dependencies' => $this->getDependencies(),
+            'routes'       => $this->getRoutes(),
+            'templates'    => $this->getTemplates(),
         ];
     }
 
     /**
      * Returns the container dependencies
      *
-     * @return string[][]
+     * @return array<string,array<int,class-string|class-string,array<int,class-string>|class-string,class-string>>
      */
     public function getDependencies(): array
     {
         return [
-            'factories' => [
+            'abstract_factories' => [
+                ReflectionBasedAbstractFactory::class,
+            ],
+            'delegators'         => [
+                Application::class => [
+                    ApplicationConfigInjectionDelegator::class,
+                ],
+            ],
+            'factories'          => [
                 ItemListerInterface::class  => ItemListerFactory::class,
                 InputFilterInterface::class => BlogArticleInputFilterFactory::class,
+            ],
+        ];
+    }
+
+    public function getRoutes(): array
+    {
+        return [
+            // Add the route for the blog index page with support for pagination
+            [
+                'path'            => '/blog[/{current:\d+}]',
+                'name'            => 'blog.index',
+                'middleware'      => [
+                    BlogIndexHandler::class,
+                ],
+                'allowed_methods' => ['GET'],
+            ],
+
+            // Add the route for viewing a blog item
+            [
+                'path'            => '/blog/item/{slug}',
+                'name'            => 'blog.item.view',
+                'middleware'      => [
+                    BlogArticleHandler::class,
+                ],
+                'allowed_methods' => ['GET'],
+            ],
+        ];
+    }
+
+    /**
+     * Returns the templates configuration
+     */
+    public function getTemplates(): array
+    {
+        return [
+            'paths' => [
+                'blog' => [
+                    __DIR__ . '/../templates/blog'
+                ],
             ],
         ];
     }

--- a/src/Entity/BlogArticle.php
+++ b/src/Entity/BlogArticle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Settermjd\MarkdownBlog\Entity;
 
+use DateMalformedStringException;
 use DateTime;
 use Michelf\MarkdownExtra;
 
@@ -27,6 +28,7 @@ final class BlogArticle
 
     /**
      * @param array<string,list<string|null>|string> $options
+     * @throws DateMalformedStringException
      */
     public function __construct(array $options = [])
     {
@@ -35,6 +37,7 @@ final class BlogArticle
 
     /**
      * @param array<string,string> $options
+     * @throws DateMalformedStringException
      */
     public function populate(array $options = []): void
     {

--- a/src/Handler/BlogArticleHandler.php
+++ b/src/Handler/BlogArticleHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Settermjd\MarkdownBlog\Handler;
+
+use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Settermjd\MarkdownBlog\Items\ItemListerInterface;
+
+final readonly class BlogArticleHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private TemplateRendererInterface $renderer,
+        private ItemListerInterface $itemLister
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $data = [
+            'blogArticle' => $this->itemLister->getArticle($request->getAttribute('slug')),
+        ];
+
+        return new HtmlResponse($this->renderer->render('blog::blog-article', $data));
+    }
+}

--- a/src/Handler/BlogIndexHandler.php
+++ b/src/Handler/BlogIndexHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Settermjd\MarkdownBlog\Handler;
+
+use ArrayIterator;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Settermjd\MarkdownBlog\Items\ItemListerInterface;
+use Settermjd\MarkdownBlog\Iterator\PublishedItemFilterIterator;
+use Settermjd\MarkdownBlog\Sorter\SortByReverseDateOrder;
+
+use function ceil;
+use function iterator_count;
+use function usort;
+
+final readonly class BlogIndexHandler implements RequestHandlerInterface
+{
+    /**
+     * The default number of records per page, if the amount isn't provided in
+     * the constructor
+     */
+    public const int RECORDS_PER_PAGE = 10;
+
+    /**
+     * The default page to render, if the page is not available in the request's
+     * query parameters
+     */
+    public const int DEFAULT_PAGE = 1;
+
+    public function __construct(
+        private TemplateRendererInterface $renderer,
+        private ItemListerInterface $itemLister,
+        private int|null $recordsPerPage = self::RECORDS_PER_PAGE
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $articles = $this->itemLister->getArticles();
+        usort($articles, new SortByReverseDateOrder());
+
+        $publishedArticles = new PublishedItemFilterIterator(
+            new ArrayIterator($articles)
+        );
+
+        $currentPage = $request->getQueryParams()['current'] ?? 1;
+        $pageCount   = (int) ceil(iterator_count($publishedArticles) / $this->recordsPerPage);
+
+        $data = [
+            'articles'  => $publishedArticles,
+            'current'   => $currentPage,
+            'pageCount' => $pageCount,
+            'previous'  => $currentPage > self::DEFAULT_PAGE,
+            'next'      => $currentPage < $pageCount,
+        ];
+
+        return new HtmlResponse($this->renderer->render('blog::blog', $data));
+    }
+}

--- a/templates/blog/blog-article.html.twig
+++ b/templates/blog/blog-article.html.twig
@@ -1,0 +1,39 @@
+{% extends '@layout/default.html.twig' %}
+
+{% block title %}{{ blogArticle.title }} | Blog{% endblock %}
+
+{% block content %}
+<div id="blogArticle">
+    <div>
+        <a href="/blog">
+            &larr; View all blog articles
+        </a>
+        <h1>
+            {{ blogArticle.title }}
+        </h1>
+        <div>
+            <div>
+                <span>
+                    Published on {{ blogArticle.getPublishDate|date("m/d/Y", "Australia/Brisbane") }}
+                </span>
+            </div>
+            <div>
+                <span>{{ blogArticle.categories|join }}</span>
+            </div>
+        </div>
+        <picture>
+            <source type="image/webp"
+                    srcset="/images/blogArticles/{{ blogArticle.image }}">
+            {% if blogArticle['fallback'] is defined and not blogArticle.fallback is empty %}
+                <img src="/images/blogArticles/{{ blogArticle.fallback }}"
+                     alt="{{ blogArticle.title }}"
+                     loading="lazy">
+            {% endif %}
+        </picture>
+        {% if blogArticle.synopsis is defined and not blogArticle.synopsis is empty %}
+            <p>{{ blogArticle.synopsis }}</p>
+        {% endif %}
+        {{ blogArticle.content|markdown_to_html }}
+    </div>
+</div>
+{% endblock %}

--- a/templates/blog/blog.html.twig
+++ b/templates/blog/blog.html.twig
@@ -1,0 +1,40 @@
+{% extends '@layout/default.html.twig' %}
+
+{% block title %}Blog{% endblock %}
+
+{% block content %}
+<div>
+    <div>
+        <h1>Blog</h1>
+    </div>
+</div>
+
+<div>
+    {% if articles is empty %}
+        <div>
+            No blog items are currently available.
+        </div>
+    {% else %}
+        <div>
+            {% for article in articles %}
+                <div>
+                    <div>
+                        <a href="/tutorial/{{ article.slug }}">
+                            <img src="/images/blog/{{ article.image }}"
+                                 alt="{{ article.title }}">
+                        </a>
+                    </div>
+                    <p>{{ article.publishDate|format_datetime() }}</p>
+                    <h3>
+                        <a href="/blog/item/{{ article.slug }}">{{ article.title }}</a>
+                    </h3>
+                    <p>{{ article.synopsis }}</p>
+                    <p><a href="/blog/item/{{ article.slug }}">&#10132; Read the tutorial</a>
+                    </p>
+                </div>
+            {% endfor %}
+        </div>
+        {{ include('@blog/includes/pagination.html.twig') }}
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/blog/includes/pagination.html.twig
+++ b/templates/blog/includes/pagination.html.twig
@@ -1,0 +1,34 @@
+{% if pageCount is defined and not pageCount is empty and pageCount > 1 %}
+    <nav>
+        <ul>
+            <!-- Previous page link -->
+            {% if previous is defined and not previous is empty %}
+                <li>
+                    <a>&Larr;</a>
+                </li>
+            {% endif %}
+
+            <!-- Numbered page links -->
+            {% for page in range(1, pageCount)%}
+                {% if page != current %}
+                    <li>
+                        <a>
+                            {{ page }}
+                        </a>
+                    </li>
+                {% else %}
+                    <li>
+                        <span>{{ page }}</span>
+                    </li>
+                {% endif %}
+            {% endfor %}
+
+            <!-- Next page link -->
+            {% if next is defined and not next is empty %}
+                <li>
+                    <a>&Rarr;</a>
+                </li>
+            {% endif %}
+        </ul>
+    </nav>
+{% endif %}

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Settermjd\MarkdownBlogTest;
+
+use Laminas\InputFilter\InputFilterInterface;
+use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
+use Mezzio\Application;
+use Settermjd\MarkdownBlog\ConfigProvider;
+use PHPUnit\Framework\TestCase;
+use Settermjd\MarkdownBlog\Items\ItemListerInterface;
+
+class ConfigProviderTest extends TestCase
+{
+    public function testHasTheRequiredDependencies(): void
+    {
+        $configProvider = new ConfigProvider();
+
+        $dependencies = $configProvider->getDependencies();
+        $this->assertSame(
+            [
+                'abstract_factories',
+                'delegators',
+                'factories',
+            ],
+            array_keys($dependencies),
+        );
+        $this->assertContains(
+            ReflectionBasedAbstractFactory::class,
+            $dependencies['abstract_factories']
+        );
+        $this->assertArrayHasKey(
+            ItemListerInterface::class,
+            $dependencies['factories'],
+        );
+        $this->assertArrayHasKey(
+            InputFilterInterface::class,
+            $dependencies['factories'],
+        );
+        $this->assertArrayHasKey(
+            Application::class, $dependencies['delegators'],
+        );
+
+        $routes = $configProvider->getRoutes();
+        $this->assertCount(2, $routes);
+    }
+}

--- a/test/Handler/BlogArticleHandlerTest.php
+++ b/test/Handler/BlogArticleHandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Settermjd\MarkdownBlogTest\Handler;
+
+use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Settermjd\MarkdownBlog\Entity\BlogArticle;
+use Settermjd\MarkdownBlog\Handler\BlogArticleHandler;
+use Settermjd\MarkdownBlog\Items\ItemListerInterface;
+
+class BlogArticleHandlerTest extends TestCase
+{
+    public function testCanHandleGetRequestWhenAnArticleMatchesTheSuppliedSlug(): void
+    {
+        $slug     = 'dockerfile-buildargs-go-out-of-scope';
+        $template = $this->createMock(TemplateRendererInterface::class);
+        $template
+            ->expects($this->once())
+            ->method('render')
+            ->with('blog::blog-article', [
+                'blogArticle' => new BlogArticle(),
+            ]);
+
+        $itemLister = $this->createMock(ItemListerInterface::class);
+        $itemLister
+            ->expects($this->once())
+            ->method('getArticle')
+            ->with($slug)
+            ->willReturn(new BlogArticle());
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request
+            ->expects($this->once())
+            ->method('getAttribute')
+            ->willReturn($slug);
+
+        $handler = new BlogArticleHandler($template, $itemLister);
+        $this->assertInstanceOf(HtmlResponse::class, $handler->handle($request));
+    }
+}

--- a/test/Handler/BlogIndexHandlerTest.php
+++ b/test/Handler/BlogIndexHandlerTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Settermjd\MarkdownBlogTest\Handler;
+
+use ArrayIterator;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Settermjd\MarkdownBlog\Entity\BlogArticle;
+use Settermjd\MarkdownBlog\Handler\BlogIndexHandler;
+use Settermjd\MarkdownBlog\Items\ItemListerInterface;
+use Settermjd\MarkdownBlog\Iterator\PublishedItemFilterIterator;
+
+class BlogIndexHandlerTest extends TestCase
+{
+    #[DataProvider('blogIndexDataProvider')]
+    public function testCanRenderBlogItemsWhenTheyAreAvailable(
+        array $articles,
+        int $currentPage,
+        int $pageCount,
+        bool $previous,
+        bool $next
+    ) {
+        $publishedArticles = new PublishedItemFilterIterator(new ArrayIterator($articles));
+        $data              = [
+            'articles'  => $publishedArticles,
+            'current'   => $currentPage,
+            'pageCount' => $pageCount,
+            'previous'  => $previous,
+            'next'      => $next,
+        ];
+
+        /** @var TemplateRendererInterface&MockObject $template */
+        $template = $this->createMock(TemplateRendererInterface::class);
+        $template
+            ->expects($this->once())
+            ->method("render")
+            ->with("blog::blog", $data);
+
+        /** @var ItemListerInterface&MockObject $itemLister */
+        $itemLister = $this->createMock(ItemListerInterface::class);
+        $itemLister
+            ->expects($this->once())
+            ->method("getArticles")
+            ->willReturn($articles);
+
+        /** @var ServerRequestInterface&MockObject $request */
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request
+            ->expects($this->once())
+            ->method("getQueryParams")
+            ->willReturn([
+                "current" => $currentPage,
+            ]);
+
+        $handler = new BlogIndexHandler($template, $itemLister);
+
+        $response = $handler->handle($request);
+
+        $this->assertInstanceOf(HtmlResponse::class, $response);
+    }
+
+    /**
+     * @return array<string, list<bool|int|list<BlogArticle>>>
+     */
+    public static function blogIndexDataProvider(): array
+    {
+        return [
+            // phpcs:disable Generic.Files.LineLength
+            "One blog item is available, and we're on the first page of records without the ability to move forward or back"        => [
+                [
+                    new BlogArticle([
+                        'slug'        => "/article-one",
+                        'title'       => "Article One",
+                        "publishDate" => "10.03.2021",
+                    ]),
+                ],
+                1,
+                1,
+                false,
+                false,
+            ],
+            "On the second of two pages of blog items, showing one item per page, with the ability to go back to the previous page" => [
+                [
+                    new BlogArticle([
+                        'slug'        => "/article-one",
+                        'title'       => "Article One",
+                        "publishDate" => "10.03.2021",
+                    ]),
+                    new BlogArticle([
+                        'slug'        => "/article-two",
+                        'title'       => "Article Two",
+                        "publishDate" => "11.03.2021",
+                    ]),
+                    new BlogArticle([
+                        'slug'        => "/article-three",
+                        'title'       => "Article Three",
+                        "publishDate" => "12.03.2021",
+                    ]),
+                    new BlogArticle([
+                        'slug'        => "/article-four",
+                        'title'       => "Article Four",
+                        "publishDate" => "13.03.2021",
+                    ]),
+                    new BlogArticle([
+                        'slug'        => "/article-five",
+                        'title'       => "Article Five",
+                        "publishDate" => "14.03.2021",
+                    ]),
+                    new BlogArticle([
+                        'slug'        => "/article-six",
+                        'title'       => "Article Six",
+                        "publishDate" => "15.03.2021",
+                    ]),
+                ],
+                2,
+                1,
+                true,
+                false,
+            ],
+            // phpcs:enable Generic.Files.LineLength
+            "On the first page of one page of blog items with a total of one blog items" => [
+                [
+                    new BlogArticle([
+                        'slug'        => "/article-one",
+                        'title'       => "Article One",
+                        "publishDate" => "10.03.2021",
+                    ]),
+                    new BlogArticle([
+                        'slug'        => "/article-two",
+                        'title'       => "Article Two",
+                        "publishDate" => "11.03.2021",
+                    ]),
+                    new BlogArticle([
+                        'slug'        => "/article-three",
+                        'title'       => "Article Three",
+                        "publishDate" => "12.03.2021",
+                    ]),
+                    new BlogArticle([
+                        'slug'        => "/article-four",
+                        'title'       => "Article Four",
+                        "publishDate" => "13.03.2021",
+                    ]),
+                    new BlogArticle([
+                        'slug'        => "/article-five",
+                        'title'       => "Article Five",
+                        "publishDate" => "14.03.2021",
+                    ]),
+                    new BlogArticle([
+                        'slug'        => "/article-six",
+                        'title'       => "Article Six",
+                        "publishDate" => "15.03.2021",
+                    ]),
+                ],
+                1,
+                1,
+                false,
+                false,
+            ],
+        ];
+    }
+
+    public function testDoesNotRendertutorialsWhenNoneAreAvailable()
+    {
+        $currentPage = 1;
+
+        $data = [
+            'articles'  => new PublishedItemFilterIterator(new ArrayIterator([])),
+            'current'   => $currentPage,
+            'pageCount' => 0,
+            'previous'  => false,
+            'next'      => false,
+        ];
+
+        /** @var ItemListerInterface&MockObject $itemLister */
+        $itemLister = $this->createMock(ItemListerInterface::class);
+        $itemLister
+            ->expects($this->once())
+            ->method("getArticles")
+            ->willReturn([]);
+
+        /** @var TemplateRendererInterface&MockObject $template */
+        $template = $this->createMock(TemplateRendererInterface::class);
+        $template
+            ->expects($this->once())
+            ->method("render")
+            ->with("blog::blog", $data);
+
+        /** @var ServerRequestInterface&MockObject $request */
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request
+            ->expects($this->once())
+            ->method("getQueryParams")
+            ->willReturn([
+                "current" => $currentPage,
+            ]);
+
+        $handler = new BlogIndexHandler($template, $itemLister);
+
+        $response = $handler->handle($request);
+
+        $this->assertInstanceOf(HtmlResponse::class, $response);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

#### Adds handlers and accompanying templates

This change adds in default/generic handler classes providing the blog's index page, as well as a blog article view page. In addition, naturally, they also have accompanying templates.

The structure of the templates was the same that I used on a project, where I have been developing the code, minus all styling, as it was very project-specific.

I want to stress that these are generic templates and generic handlers that are expected to be overridden at some point not long after the package is added to a Mezzio project. But, they're there to help get users up and running as quickly as possible.

#### Updates the ConfigProvider

The project's ConfigProvider class has two new functions. The first, `getRoutes()`, registers routes for the new handlers with the application's routing table. The second, `getTemplates()`, adds the blog's default template directory to the application's templates path.

#### Updates the supported PHP versions

PHP 8.1 and 8.2 have been removed from the list of PHP versions which the project supports. The main reason for this is to ensure that, at a minimum, all language features used in the respective classes are guaranteed to be supported.