### PR TITLE
Add get related articles functionality

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" colors="true" cacheDirectory=".phpunit.cache" beStrictAboutCoverageMetadata="true">
+<phpunit
+  beStrictAboutCoverageMetadata="true"
+  beStrictAboutOutputDuringTests="true"
+  bootstrap="vendor/autoload.php"
+  cacheDirectory=".phpunit.cache"
+  colors="true"
+  displayDetailsOnSkippedTests="true"
+  displayDetailsOnTestsThatTriggerDeprecations="true"
+  displayDetailsOnTestsThatTriggerErrors="true"
+  displayDetailsOnTestsThatTriggerNotices="true"
+  displayDetailsOnTestsThatTriggerWarnings="true"
+  executionOrder="depends,defects"
+  failOnRisky="true"
+  failOnWarning="true"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+>
   <testsuites>
     <testsuite name="default">
       <directory suffix="Test.php">test</directory>

--- a/src/Handler/BlogArticleHandler.php
+++ b/src/Handler/BlogArticleHandler.php
@@ -21,8 +21,10 @@ final readonly class BlogArticleHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $data = [
-            'article' => $this->itemLister->getArticle($request->getAttribute('slug')),
+        $article = $this->itemLister->getArticle($request->getAttribute('slug'));
+        $data    = [
+            'article'         => $article,
+            'relatedArticles' => $this->itemLister->getRelatedArticles($article),
         ];
 
         return new HtmlResponse($this->renderer->render('blog::blog-article', $data));

--- a/src/Items/Adapter/ItemListerFilesystem.php
+++ b/src/Items/Adapter/ItemListerFilesystem.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Settermjd\MarkdownBlog\Items\Adapter;
 
+use ArrayIterator;
 use DirectoryIterator;
+use Iterator;
 use Laminas\Hydrator\ArraySerializableHydrator;
 use Laminas\InputFilter\InputFilterInterface;
 use Mni\FrontYAML\Document;
@@ -14,6 +16,7 @@ use Psr\SimpleCache\CacheInterface;
 use Settermjd\MarkdownBlog\Entity\BlogArticle;
 use Settermjd\MarkdownBlog\Items\ItemListerInterface;
 use Settermjd\MarkdownBlog\Iterator\MarkdownFileFilterIterator;
+use Settermjd\MarkdownBlog\Iterator\RelatedPostsFilterIterator;
 use SplFileInfo;
 
 use function array_merge;
@@ -28,6 +31,7 @@ final class ItemListerFilesystem implements ItemListerInterface
     public const CACHE_KEY_SUFFIX_ALL      = 'all';
     public const CACHE_KEY_SUFFIX_UPCOMING = 'upcoming';
     public const CACHE_KEY_SUFFIX_PAST     = 'past';
+    public const CACHE_KEY_SUFFIX_RELATED  = 'related';
 
     protected MarkdownFileFilterIterator $episodeIterator;
 
@@ -66,6 +70,17 @@ final class ItemListerFilesystem implements ItemListerInterface
         }
 
         return $this->buildArticlesList();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRelatedArticles(BlogArticle $blogArticle): Iterator
+    {
+        return new RelatedPostsFilterIterator(
+            new ArrayIterator($this->getArticles()),
+            $blogArticle
+        );
     }
 
     /**

--- a/src/Items/ItemListerInterface.php
+++ b/src/Items/ItemListerInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Settermjd\MarkdownBlog\Items;
 
+use Iterator;
 use Settermjd\MarkdownBlog\Entity\BlogArticle;
 
 /**
@@ -17,6 +18,11 @@ interface ItemListerInterface
      * @return array<int,BlogArticle>
      */
     public function getArticles(): array;
+
+    /**
+     * Returns an array of BlogArticles that are related to the supplied one
+     */
+    public function getRelatedArticles(BlogArticle $blogArticle): Iterator;
 
     /**
      * Returns a single article matching the slug provided

--- a/src/Iterator/FilterPostByTagIterator.php
+++ b/src/Iterator/FilterPostByTagIterator.php
@@ -39,6 +39,7 @@ final class FilterPostByTagIterator extends FilterIterator
 
         // Filter out empty/null entries, which will break array_map's use of strtolower
         $tags = array_filter($post->getTags());
+
         if (! empty($tags)) {
             return in_array($this->tag, array_map('strtolower', $tags));
         }

--- a/src/Iterator/PublishedItemFilterIterator.php
+++ b/src/Iterator/PublishedItemFilterIterator.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace Settermjd\MarkdownBlog\Iterator;
 
-use Countable;
 use DateTime;
 use Exception;
 use FilterIterator;
 use Iterator;
 use Settermjd\MarkdownBlog\Entity\BlogArticle;
-
-use function iterator_count;
 
 /**
  * @template TKey of int
@@ -19,7 +16,7 @@ use function iterator_count;
  * @template TIterator of Iterator
  * @template-extends FilterIterator<TKey,TValue,TIterator>
  */
-final class PublishedItemFilterIterator extends FilterIterator implements Countable
+final class PublishedItemFilterIterator extends FilterIterator
 {
     public function __construct(Iterator $iterator)
     {
@@ -37,10 +34,5 @@ final class PublishedItemFilterIterator extends FilterIterator implements Counta
         $episode = $this->getInnerIterator()->current();
 
         return $episode->getPublishDate() <= new DateTime();
-    }
-
-    public function count(): int
-    {
-        return iterator_count($this->getInnerIterator());
     }
 }

--- a/templates/blog/laminas/blog.phtml
+++ b/templates/blog/laminas/blog.phtml
@@ -7,7 +7,7 @@
 </div>
 
 <div>
-    <?php if (count($this->articles) === 0): ?>
+    <?php if (iterator_count($this->articles) === 0): ?>
         <div id="no-blog-items">
             No blog items are currently available.
         </div>

--- a/templates/blog/plates/blog.phtml
+++ b/templates/blog/plates/blog.phtml
@@ -7,7 +7,7 @@
 </div>
 
 <div>
-    <?php if (count($articles) === 0): ?>
+    <?php if (iterator_count($articles) === 0): ?>
         <div id="no-blog-items">
             No blog items are currently available.
         </div>

--- a/test/Integration/BlogIndexPageTest.php
+++ b/test/Integration/BlogIndexPageTest.php
@@ -47,9 +47,14 @@ final class BlogIndexPageTest extends TestCase
 
         /** @var BlogArticleHandler $handler */
         $handler  = $this->container->get(BlogArticleHandler::class);
-        $response = $handler->handle($this->createConfiguredMock(ServerRequestInterface::class, [
-            'getAttribute' => 'blogArticle-0011',
-        ]));
+        $response = $handler->handle(
+            $this->createConfiguredMock(
+                ServerRequestInterface::class,
+                [
+                    'getAttribute' => 'blogArticle-0011',
+                ]
+            )
+        );
 
         self::assertInstanceOf(HtmlResponse::class, $response);
         $body    = $response->getBody()->getContents();

--- a/test/Unit/Handler/BlogArticleHandlerTest.php
+++ b/test/Unit/Handler/BlogArticleHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Settermjd\MarkdownBlogTest\Unit\Handler;
 
+use ArrayIterator;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Mezzio\Template\TemplateRendererInterface;
 use PHPUnit\Framework\TestCase;
@@ -11,18 +12,25 @@ use Psr\Http\Message\ServerRequestInterface;
 use Settermjd\MarkdownBlog\Entity\BlogArticle;
 use Settermjd\MarkdownBlog\Handler\BlogArticleHandler;
 use Settermjd\MarkdownBlog\Items\ItemListerInterface;
+use Settermjd\MarkdownBlog\Iterator\RelatedPostsFilterIterator;
 
 class BlogArticleHandlerTest extends TestCase
 {
     public function testCanHandleGetRequestWhenAnArticleMatchesTheSuppliedSlug(): void
     {
-        $slug     = 'dockerfile-buildargs-go-out-of-scope';
-        $template = $this->createMock(TemplateRendererInterface::class);
+        $article         = new BlogArticle();
+        $relatedArticles = new RelatedPostsFilterIterator(
+            new ArrayIterator([]),
+            new BlogArticle()
+        );
+        $slug            = 'dockerfile-buildargs-go-out-of-scope';
+        $template        = $this->createMock(TemplateRendererInterface::class);
         $template
             ->expects($this->once())
             ->method('render')
             ->with('blog::blog-article', [
-                'article' => new BlogArticle(),
+                'article'         => $article,
+                'relatedArticles' => $relatedArticles,
             ]);
 
         $itemLister = $this->createMock(ItemListerInterface::class);
@@ -31,6 +39,11 @@ class BlogArticleHandlerTest extends TestCase
             ->method('getArticle')
             ->with($slug)
             ->willReturn(new BlogArticle());
+        $itemLister
+            ->expects($this->once())
+            ->method('getRelatedArticles')
+            ->with($article)
+            ->willReturn($relatedArticles);
 
         $request = $this->createMock(ServerRequestInterface::class);
         $request

--- a/test/Unit/InputFilter/BlogArticleInputFilterFactoryTest.php
+++ b/test/Unit/InputFilter/BlogArticleInputFilterFactoryTest.php
@@ -77,6 +77,52 @@ If you've been following [my journey so far](/tags/golang/), I've been working t
 However, toward the end of the time, before the unexpected break, I felt that it was becoming quite arbitrary to follow that approach.
     This is because the things I was learning weren't tied to a practical project which held any genuine sense of meaning for me.",
                     'image'       => 'learning-golang-day13.png',
+                    'publishDate' => '02.04.2023',
+                    'slug'        => 'learning-golang/day-13/',
+                    'synopsis'    => 'Here we are on day 13. Today, I continued learning Golang by working on the Golang version of my PHP/Python weather station, adding a function to render static pages. Let me share my learnings with you.',
+                    'tags'        => [
+                        'Golang',
+                        'Go',
+                        'Gorilla Mux',
+                        'Regular Expressions',
+                        'vim-go',
+                    ],
+                    'title'       => 'Learning Golang, Day 13 — Regular Expressions and the Gorilla Mux Router',
+                ],
+                [
+                    'categories'  => [
+                        'Education',
+                    ],
+                    'content'     => "After an unexpected hiatus, I'm back learning Golang and continuing to grow my knowledge in this wonderful, fun, and light language.
+If you've been following [my journey so far](/tags/golang/), I've been working through [the Go Tour](https://go.dev/tour/welcome/1) as a way of having a proper sense of structure to my learning efforts.
+
+However, toward the end of the time, before the unexpected break, I felt that it was becoming quite arbitrary to follow that approach.
+    This is because the things I was learning weren't tied to a practical project which held any genuine sense of meaning for me.",
+                    'image'       => 'learning-golang-day13.png',
+                    'publishDate' => '02.04.2023',
+                    'slug'        => 'learning-golang/day-13/',
+                    'synopsis'    => 'Here we are on day 13. Today, I continued learning Golang by working on the Golang version of my PHP/Python weather station, adding a function to render static pages. Let me share my learnings with you.',
+                    'tags'        => [
+                        'Golang',
+                        'Go',
+                        'Gorilla Mux',
+                        'Regular Expressions',
+                        'vim-go',
+                    ],
+                    'title'       => 'Learning Golang, Day 13 — Regular Expressions and the Gorilla Mux Router',
+                ],
+            ],
+            [
+                [
+                    'categories'  => [
+                        'Education',
+                    ],
+                    'content'     => "After an unexpected hiatus, I'm back learning Golang and continuing to grow my knowledge in this wonderful, fun, and light language.
+If you've been following [my journey so far](/tags/golang/), I've been working through [the Go Tour](https://go.dev/tour/welcome/1) as a way of having a proper sense of structure to my learning efforts.
+
+However, toward the end of the time, before the unexpected break, I felt that it was becoming quite arbitrary to follow that approach.
+    This is because the things I was learning weren't tied to a practical project which held any genuine sense of meaning for me.",
+                    'image'       => 'learning-golang-day13.png',
                     'publishDate' => '2023-04-02',
                     'slug'        => 'learning-golang/day-13/',
                     'synopsis'    => 'Here we are on day 13. Today, I continued learning Golang by working on the Golang version of my PHP/Python weather station, adding a function to render static pages. Let me share my learnings with you.',

--- a/test/Unit/Iterator/DataTrait.php
+++ b/test/Unit/Iterator/DataTrait.php
@@ -13,7 +13,7 @@ use function sprintf;
 
 trait DataTrait
 {
-  /** @var array<string,array<string,string>> */
+    /** @var array<string,array<string,string>> */
     private array $structure;
 
     public function setupArticleData(): void
@@ -28,6 +28,11 @@ trait DataTrait
             file_get_contents(__DIR__ . '/../_data/posts/item-0004.md'),
             (new DateTime())->add(new DateInterval('P5D'))->format('d.m.Y')
         );
+        $item005Content = sprintf(
+            file_get_contents(__DIR__ . '/../_data/posts/item-0005.md'),
+            (new DateTime())->sub(new DateInterval('P1D'))->format('d.m.Y')
+        );
+        $item006Content = file_get_contents(__DIR__ . '/../_data/posts/item-0001.md');
 
         $this->structure = [
             'posts' => [
@@ -35,6 +40,8 @@ trait DataTrait
                 'item-0002.md' => $item002Content,
                 'item-0003.md' => $item003Content,
                 'item-0004.md' => $item004Content,
+                'item-0005.md' => $item005Content,
+                'item-0006.md' => $item006Content,
             ],
         ];
         vfsStream::setup('root', null, $this->structure);

--- a/test/Unit/Iterator/EpisodeFilterIteratorTest.php
+++ b/test/Unit/Iterator/EpisodeFilterIteratorTest.php
@@ -20,16 +20,9 @@ final class EpisodeFilterIteratorTest extends TestCase
 {
     use DataTrait;
 
-    protected function setUp(): void
-    {
-        $this->setupArticleData();
-    }
-
     public function testCanFilterUpcomingItems(): void
     {
-        $this->setUp();
-
-        vfsStream::setup('root', null, $this->structure);
+        $this->setupArticleData();
 
         $blogArticleInputFilterFactory = new BlogArticleInputFilterFactory();
         $itemLister                    = new ItemListerFilesystem(
@@ -54,9 +47,7 @@ final class EpisodeFilterIteratorTest extends TestCase
 
     public function testCanGetAllPastItems(): void
     {
-        $this->setUp();
-
-        vfsStream::setup('root', null, $this->structure);
+        $this->setupArticleData();
 
         $blogArticleInputFilterFactory = new BlogArticleInputFilterFactory();
         $itemLister                    = new ItemListerFilesystem(

--- a/test/Unit/Iterator/FilterPostByCategoryIteratorTest.php
+++ b/test/Unit/Iterator/FilterPostByCategoryIteratorTest.php
@@ -37,7 +37,7 @@ final class FilterPostByCategoryIteratorTest extends TestCase
 
     /**
      * @return (int|string)[][]
-     * @psalm-return list{list{'Podcasts', 0}, list{'Software Development', 3}, list{'Public Speaking', 1}}
+     * @psalm-return list{list{'Podcasts', 0}, list{'Software Development', 5}, list{'Public Speaking', 0}}
      */
     public static function filterByCategoryDataProvider(): array
     {
@@ -48,7 +48,7 @@ final class FilterPostByCategoryIteratorTest extends TestCase
             ],
             [
                 'Software Development',
-                4,
+                5,
             ],
             [
                 'Public Speaking',

--- a/test/Unit/Iterator/FilterPostByTagIteratorTest.php
+++ b/test/Unit/Iterator/FilterPostByTagIteratorTest.php
@@ -41,7 +41,7 @@ final class FilterPostByTagIteratorTest extends TestCase
 
     /**
      * @return (int|string)[][]
-     * @psalm-return list{list{'Kubernetes', 0}, list{'PHP', 3}, list{'Docker', 1}, list{'slim framework', 1}}
+     * @psalm-return list{list{'Kubernetes', 0}, list{'PHP', 3}, list{'Docker', 1}, list{'Slim Framework', 2}}
      */
     public static function filterByTagDataProvider(): array
     {
@@ -59,8 +59,8 @@ final class FilterPostByTagIteratorTest extends TestCase
                 1,
             ],
             [
-                'slim framework',
-                1,
+                'Slim Framework',
+                2,
             ],
         ];
     }

--- a/test/Unit/Iterator/FilterPostByTagIteratorTest.php
+++ b/test/Unit/Iterator/FilterPostByTagIteratorTest.php
@@ -6,6 +6,9 @@ namespace Settermjd\MarkdownBlogTest\Unit\Iterator;
 
 use ArrayIterator;
 use Mni\FrontYAML\Parser;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -30,9 +33,11 @@ final class FilterPostByTagIteratorTest extends TestCase
         $itemLister                    = new ItemListerFilesystem(
             vfsStream::url('root/posts'),
             new Parser(),
-            $blogArticleInputFilterFactory()
+            $blogArticleInputFilterFactory(),
+            logger: (new Logger('debug'))->pushHandler(new StreamHandler('/tmp/test.debug.log', Level::Debug)),
         );
-        $posts                         = new FilterPostByTagIterator(
+
+        $posts = new FilterPostByTagIterator(
             new ArrayIterator($itemLister->getArticles()),
             $tag
         );

--- a/test/Unit/Iterator/RelatedPostsFilterIteratorTest.php
+++ b/test/Unit/Iterator/RelatedPostsFilterIteratorTest.php
@@ -84,7 +84,7 @@ EOF,
                     'tags'        => ['PHP', 'Docker'],
                     'categories'  => ['Software Development'],
                 ],
-                3,
+                4,
                 [
                     'item-0004',
                 ],

--- a/test/Unit/_data/posts/item-0005.md
+++ b/test/Unit/_data/posts/item-0005.md
@@ -1,0 +1,23 @@
+---
+publish_date: %s
+slug: item-0005
+title: Lorem ipsum dolor sit amet.
+synopsis: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed sapien odio. Vestibulum et orci.
+image: http://traffic.libsyn.com/thegeekyfreelancer/FreeTheGeek-Episode0005.mp3
+tags:
+  - "Developer Education"
+categories:
+  - "Technical Writing"
+---
+### Synopsis
+
+In this item, I have a fireside chat with Yitzchok Willroth, the one and only [coderabbi](https://twitter.com/@coderabbi), about a his [Wisdom as a Service World Tour](http://wisdomworldtour.com/).
+
+We talk about what it's like to run the tour, the time involved, the energy required, and how it's been received. We also talk about the value of human skills (otherwise known as soft skills), the value of getting up and sharing your knowledge with the community, via public speaking, **and much, much more**.
+
+### Related Links
+
+- [Wisdom as a Service World Tour](http://wisdomworldtour.com/)
+- [coderabbi](https://twitter.com/@coderabbi)
+- [ShorePHP User Group](http://shorephp.org/)
+- [NYPHP User Group](http://nyphp.org/)

--- a/test/Unit/_data/posts/item-0006.md
+++ b/test/Unit/_data/posts/item-0006.md
@@ -1,6 +1,6 @@
 ---
-publish_date: "2015-07-13"
-slug: item-0001
+publish_date: 2015-07-13
+slug: item-0006
 synopsis: In this, the first item, Matt talks about what lead to the podcast getting started who motivated him and inspired him to get started. After that, he discusses a fantastic book that all freelancers should read.
 title: Getting Underway, The E-Myth Revisited, and Networking For Success
 image: http://traffic.libsyn.com/thegeekyfreelancer/FreeTheGeek-Episode0001.mp3


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This is something that I didn't know that I needed, I think, until recently. That being, the ability to get a list of articles that are related to the current one. The criteria for what makes a related tutorial is quite simplistic: do they share the same _categories_ or _tags_. That's, honestly, it. But, for now, it works.
